### PR TITLE
feat: Recommend/Chatbot에 OpenTelemetry 분산 트레이싱 및 Prometheus 메트릭 추가

### DIFF
--- a/services/chatbot/app/main.py
+++ b/services/chatbot/app/main.py
@@ -2,6 +2,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 from app.api.chat import router as chat_router
 from app.api.history import router as history_router
 from app.db.clients import init_clients, close_clients
@@ -42,6 +43,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+Instrumentator().instrument(app).expose(app)
 
 app.include_router(chat_router)
 app.include_router(history_router)

--- a/services/chatbot/app/main.py
+++ b/services/chatbot/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
+from app.tracing import setup_tracing
 from app.api.chat import router as chat_router
 from app.api.history import router as history_router
 from app.db.clients import init_clients, close_clients
@@ -44,6 +45,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+setup_tracing(app)
 Instrumentator().instrument(app).expose(app)
 
 app.include_router(chat_router)

--- a/services/chatbot/app/tracing.py
+++ b/services/chatbot/app/tracing.py
@@ -1,0 +1,26 @@
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+
+def setup_tracing(app):
+    """OTLP_ENDPOINT 환경변수가 설정된 경우에만 트레이싱 활성화"""
+    otlp_endpoint = os.getenv("OTLP_ENDPOINT")
+    if not otlp_endpoint:
+        return
+
+    resource = Resource.create({
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "chatbot"),
+        "service.namespace": "moyeobab",
+    })
+
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app)

--- a/services/chatbot/requirements.txt
+++ b/services/chatbot/requirements.txt
@@ -23,6 +23,9 @@ pydantic-settings>=2.0.0      # BaseSettings (.env 로딩)
 python-dotenv>=1.0.0
 httpx>=0.27.0
 aiosqlite>=0.20.0
+# ── Prometheus 메트릭 ──
+prometheus-fastapi-instrumentator
+
 # ── 모니터링 및 LangChain (RAG 관측) ──
 langsmith>=0.7.17
 langchain>=1.2.12

--- a/services/chatbot/requirements.txt
+++ b/services/chatbot/requirements.txt
@@ -26,6 +26,12 @@ aiosqlite>=0.20.0
 # ── Prometheus 메트릭 ──
 prometheus-fastapi-instrumentator
 
+# ── 분산 트레이싱 (OpenTelemetry) ──
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-fastapi
+
 # ── 모니터링 및 LangChain (RAG 관측) ──
 langsmith>=0.7.17
 langchain>=1.2.12

--- a/services/recommend/app/main.py
+++ b/services/recommend/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
+from app.tracing import setup_tracing
 
 from app.core.config import settings
 from app.core.model_loader import load_model
@@ -64,6 +65,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+setup_tracing(app)
 Instrumentator().instrument(app).expose(app)
 
 

--- a/services/recommend/app/tracing.py
+++ b/services/recommend/app/tracing.py
@@ -1,0 +1,26 @@
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+
+def setup_tracing(app):
+    """OTLP_ENDPOINT 환경변수가 설정된 경우에만 트레이싱 활성화"""
+    otlp_endpoint = os.getenv("OTLP_ENDPOINT")
+    if not otlp_endpoint:
+        return
+
+    resource = Resource.create({
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "recommend"),
+        "service.namespace": "moyeobab",
+    })
+
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app)

--- a/services/recommend/requirements.txt
+++ b/services/recommend/requirements.txt
@@ -17,6 +17,12 @@ pydantic
 # Monitoring (Prometheus Metrics)
 prometheus-fastapi-instrumentator
 
+# Distributed Tracing (OpenTelemetry)
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-fastapi
+
 
 lightgbm>=4.3.0
 numpy>=1.26.0


### PR DESCRIPTION
## 개요

Grafana Tempo 기반 분산 트레이싱을 위해 Recommend/Chatbot 서비스에 OpenTelemetry SDK 추가. Spring Boot가 전파하는 W3C traceparent 헤더를 자동 파싱하여 서비스 간 trace 연결.

## 변경 사항

- Recommend: opentelemetry-instrumentation-fastapi 추가 및 tracing.py 모듈 생성
- Chatbot: 동일 + prometheus-fastapi-instrumentator 추가 (메트릭 수집)
- OTLP_ENDPOINT 환경변수 없으면 트레이싱 비활성화 (로컬 개발 영향 없음)